### PR TITLE
Update color scheme to minimal black with blue on hover

### DIFF
--- a/src/components/ContentDisplay.astro
+++ b/src/components/ContentDisplay.astro
@@ -87,12 +87,12 @@ const isList = variant === 'list'
     {external ? (
       <ArrowRightUp
         fill="currentColor"
-        class="mr-0 h-5 w-5 shrink-0 text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:-translate-y-1 sm:mr-2"
+        class="mr-0 h-5 w-5 shrink-0 group-hover:text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:-translate-y-1 sm:mr-2"
       />
     ) : (
       <ArrowRight
         fill="currentColor"
-        class="mr-0 h-5 w-5 shrink-0 text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-2 sm:mr-2"
+        class="mr-0 h-5 w-5 shrink-0 group-hover:text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-2 sm:mr-2"
       />
     )}
   )}

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -3,13 +3,14 @@ import UnifiedLink from './UnifiedLink.astro'
 import ArrowSquiggle from '@/assets/icons/arrow-squiggle.svg'
 import Image from 'astro/components/Image.astro'
 import Me from '@/assets/images/me.jpg'
+import { socialLinks } from '@/lib/site'
 ---
 
 <section
   class="relative mt-8 pb-4 flex flex-wrap-reverse rounded-xl text-base sm:border sm:text-lg md:mt-30 md:mb-30">
   <div class="p-0 sm:w-2/3 sm:p-8">
-    <h1 class="text-3xl font-bold sm:text-4xl">
-      <span class="text-blue-600">Hello</span>, I'm Chris Nowicki
+    <h1 class="text-3xl sm:text-4xl">
+      <span class="font-bold">Hello</span>, I'm Chris Nowicki
     </h1>
     <p class="mt-3 text-lg sm:text-xl">
       Developer Experience Engineer at
@@ -52,7 +53,7 @@ import Me from '@/assets/images/me.jpg'
         href="/contact"
         size="lg"
         variant="default"
-        class="bg-blue-600 text-center uppercase">Contact Me</UnifiedLink
+        class="bg-black text-center uppercase">Contact Me</UnifiedLink
       >
       <UnifiedLink
         href="https://buymeacoffee.com/chrisnowicki"
@@ -63,7 +64,7 @@ import Me from '@/assets/images/me.jpg'
       >
     </div>
   </div>
-  <div class="mb-6 flex items-start justify-center pt-6 sm:mb-0 sm:w-1/3">
+  <div class="mb-6 flex flex-col items-center pt-6 sm:mb-0 sm:w-1/3">
     <Image
       src={Me}
       alt="Photo of me"

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -17,10 +17,7 @@ const pathname = new URL(Astro.request.url).pathname.split('/')[1]
     <a
       href="/"
       class={cn(
-        'font-cursive rounded-full border px-2 py-1 text-2xl transition-all duration-100 ease-in-out hover:scale-105 hover:-rotate-10 hover:shadow-lg',
-        pathname === '' ?
-          'border-blue-600 text-blue-600'
-        : 'border-black/90 text-black/90'
+        'font-cursive rounded-full border px-2 py-1 text-2xl transition-all duration-100 ease-in-out hover:scale-105 hover:-rotate-10 hover:shadow-lg border-black/90 text-black/90',
       )}>
       CN
     </a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -87,11 +87,11 @@ const ogImageUrl = generateOgImageUrl({
                     </p>
                     <UnifiedLink
                       href={`/blog/${post.id}`}
-                      class="flex items-center gap-2 font-normal text-blue-600 hover:underline">
+                      class="flex items-center gap-2 font-normal group-hover:text-blue-600 hover:underline">
                       Read More
                       <ArrowRight
                         fill="currentColor"
-                        class="mr-0 h-5 w-5 shrink-0 text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-2 sm:mr-2"
+                        class="mr-0 h-5 w-5 shrink-0 group-hover:text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-2 sm:mr-2"
                       />
                     </UnifiedLink>
                   </div>

--- a/src/pages/speaking.astro
+++ b/src/pages/speaking.astro
@@ -102,11 +102,11 @@ const ogImageUrl = generateOgImageUrl({
                             href={talk.link}
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="flex items-center gap-2 text-sm text-blue-600 hover:underline">
+                            class="flex items-center gap-2 text-sm group-hover:text-blue-600 hover:underline">
                             Watch Video
                             <ArrowRight
                               fill="currentColor"
-                              class="h-4 w-4 shrink-0 text-blue-600 transition-all duration-200 ease-in-out group-hover/talk:translate-x-1"
+                              class="h-4 w-4 shrink-0 group-hover:text-blue-600 transition-all duration-200 ease-in-out group-hover/talk:translate-x-1"
                             />
                           </a>
                         )}


### PR DESCRIPTION
## Changes

This PR updates the color scheme across the site to a more minimal design with black as the primary color and blue accents only appearing on hover interactions.

### Updates:
- **Hero section**: Removed blue from 'Hello' text and Contact button (now black)
- **NavBar**: Removed conditional blue styling from logo
- **ContentDisplay & Links**: Blue color now only appears on hover instead of always visible
- **Hero layout**: Adjusted image container to use flex-col for better alignment

### Benefits:
- More minimal and clean visual design
- Better visual hierarchy with blue as an accent on interaction
- Consistent color treatment across components