### PR TITLE
style: remove blue accents and improve design consistency

### DIFF
--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -22,7 +22,7 @@ const socialIconClass =
       reach out on social media or send me an email at{' '}
       <a
         href="mailto:hello@chrisnowicki.dev"
-        class="font-bold hover:text-blue-600 hover:underline">
+        class="font-bold hover:text-black hover:underline">
         hello@chrisnowicki.dev
       </a>.
     </p>

--- a/src/components/ContentDisplay.astro
+++ b/src/components/ContentDisplay.astro
@@ -36,7 +36,7 @@ const isList = variant === 'list'
   class={cn(
     'group transition-all duration-200 ease-in-out',
     isCard && 'block h-full sm:min-h-[350px] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm hover:-translate-y-2 hover:shadow-lg',
-    isList && 'flex items-center justify-between border-b pb-2 hover:border-blue-600',
+    isList && 'flex items-center justify-between hover:bg-gray-100 rounded-lg px-2 py-2 border',
     className
   )}
   data-astro-prefetch >
@@ -64,7 +64,6 @@ const isList = variant === 'list'
     isList && 'mr-4'
   )}>
     <h3 class={cn(
-      'transition-colors group-hover:text-blue-600',
       isCard && 'mb-0 sm:mb-2 sm:min-h-[2.5em] text-base sm:text-lg font-bold wrap-break-words',
       isList && 'text-base font-semibold sm:text-lg'
     )}>
@@ -73,7 +72,6 @@ const isList = variant === 'list'
 
     {description && (
       <p class={cn(
-        'transition-colors group-hover:text-blue-600',
         isCard && 'mb-4 flex-1 text-sm text-gray-600',
         isList && 'text-foreground-muted text-sm sm:text-base'
       )}>
@@ -87,12 +85,12 @@ const isList = variant === 'list'
     {external ? (
       <ArrowRightUp
         fill="currentColor"
-        class="mr-0 h-5 w-5 shrink-0 group-hover:text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:-translate-y-1 sm:mr-2"
+        class="mr-0 h-5 w-5 shrink-0 text-muted-foreground group-hover:text-black transition-all duration-200 ease-in-out group-hover:translate-x-1 group-hover:-translate-y-1 sm:mr-2"
       />
     ) : (
       <ArrowRight
         fill="currentColor"
-        class="mr-0 h-5 w-5 shrink-0 group-hover:text-blue-600 transition-all duration-200 ease-in-out group-hover:translate-x-2 sm:mr-2"
+        class="mr-0 h-5 w-5 shrink-0 text-muted-foreground group-hover:text-black transition-all duration-200 ease-in-out group-hover:translate-x-2 sm:mr-2"
       />
     )}
   )}

--- a/src/components/ContentSection.astro
+++ b/src/components/ContentSection.astro
@@ -37,9 +37,8 @@ const {
       viewAllLink && (
         <a
           href={viewAllLink.href}
-          class="text-primary text-base hover:text-blue-600 hover:underline sm:text-base"
-          data-astro-prefetch
-        >
+          class="text-muted-foreground text-base hover:text-black"
+          data-astro-prefetch>
           {viewAllLink.text}
         </a>
       )

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ const footerLinks = [{ href: '/', text: 'home' }, ...navLinks]
 ---
 
 <Container>
-  <footer class="mb-4 mt-12 sm:flex-row sm:gap-0">
+  <footer class="mt-12 mb-4 sm:flex-row sm:gap-0">
     <div class="flex w-full flex-col items-start text-sm sm:w-2/3">
       <p>
         <strong>Sitemap:</strong>
@@ -14,7 +14,10 @@ const footerLinks = [{ href: '/', text: 'home' }, ...navLinks]
         {
           footerLinks.map((link, index, array) => (
             <span>
-              <a href={link.href} class="hover:text-blue-600" data-astro-prefetch>
+              <a
+                href={link.href}
+                class="text-muted-foreground hover:text-black"
+                data-astro-prefetch>
                 {link.text}
               </a>
               {index < array.length - 1 && ' / '}
@@ -23,9 +26,39 @@ const footerLinks = [{ href: '/', text: 'home' }, ...navLinks]
         }
       </p>
       <p>
-        <strong>Built With:</strong> Astro, Svelte, TypeScript, Tailwind, and lots of <span
-          class="hover:animate-pulse">❤</span
-        >
+        <strong>Built With:</strong>{' '}
+        <a
+          href="https://astro.build"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground -mr-1 hover:text-black">
+          Astro
+        </a>
+        ,{' '}
+        <a
+          href="https://svelte.dev"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground -mr-1 hover:text-black">
+          Svelte
+        </a>
+        ,{' '}
+        <a
+          href="https://www.typescriptlang.org"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground -mr-1 hover:text-black">
+          TypeScript
+        </a>
+        ,{' '}
+        <a
+          href="https://tailwindcss.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground -mr-1 hover:text-black">
+          Tailwind
+        </a>
+        , and lots of <span class="hover:animate-pulse">❤</span>
       </p>
     </div>
   </footer>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -7,7 +7,7 @@ import { socialLinks } from '@/lib/site'
 ---
 
 <section
-  class="relative mt-8 pb-4 flex flex-wrap-reverse rounded-xl text-base sm:border sm:text-lg md:mt-30 md:mb-30">
+  class="relative mt-8 flex flex-wrap-reverse rounded-xl pb-4 text-base sm:border sm:text-lg md:mt-30 md:mb-30">
   <div class="p-0 sm:w-2/3 sm:p-8">
     <h1 class="text-3xl sm:text-4xl">
       <span class="font-bold">Hello</span>, I'm Chris Nowicki
@@ -18,6 +18,7 @@ import { socialLinks } from '@/lib/site'
         href="https://www.commerce.com"
         ariaLabel="Visit the Commerce website"
         target="_blank"
+        class="text-muted-foreground hover:text-black"
         >Commerce.
       </UnifiedLink>
     </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,10 @@
 ---
+import Container from '@/components/Container.astro'
+import PageLayout from '@/layouts/PageLayout.astro'
 import ContactSection from '@/components/ContactSection.astro'
 import ContentSection from '@/components/ContentSection.astro'
+import Hero from '@/components/Hero.astro'
 import { HOME, NUMBER_OF_ENTRIES } from '@/lib/site'
-import Container from '../components/Container.astro'
-import PageLayout from '../layouts/PageLayout.astro'
-import Hero from '../components/Hero.astro'
 import { getBlogPosts } from '@/utils/blog-helpers'
 import { getSpeakingData } from '@/utils/speaking-helpers'
 
@@ -50,7 +50,7 @@ const speakingItems = speaking.map((engagement) => ({
           viewAllLink={{ href: '/speaking', text: 'View all engagements' }}
           items={speakingItems}
           variant="list"
-          class="mb-0 sm:mb-0"
+          class="mb-0"
         />
       )
     }


### PR DESCRIPTION
## Changes

This PR removes blue accent colors throughout the site and improves design consistency with a cleaner, more minimal aesthetic.

### Color Scheme Updates
- Replace all blue accent colors (`text-blue-600`, `hover:text-blue-600`) with black/muted-foreground
- Update hover states to use consistent `hover:text-black` styling
- Maintain visual hierarchy with muted-foreground for default states

### Component Updates
- **ContentDisplay**: Update hover states and border styling for list variant
- **ContentSection**: Update view all link styling
- **ContactSection**: Update email link hover color
- **Footer**: Add clickable links to tech stack (Astro, Svelte, TypeScript, Tailwind)
- **Hero**: Add styling to Commerce link

### Code Quality
- Clean up imports in `index.astro` to use `@/` aliases consistently
- Remove redundant CSS classes (`sm:mb-0` when `mb-0` already applies)
- Improve import organization (layout → components → lib → utils)

## Files Changed
- `src/components/ContactSection.astro` - Updated email link hover color
- `src/components/ContentDisplay.astro` - Updated hover states and border styling
- `src/components/ContentSection.astro` - Updated view all link styling
- `src/components/Footer.astro` - Added tech stack links and updated colors
- `src/components/Hero.astro` - Added Commerce link styling
- `src/pages/index.astro` - Cleaned up imports and removed redundant classes