### PR TITLE
docs: replace default README with personalized site documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,78 @@
-# Astro Starter Kit: Basics
+# chrisnowicki.dev
 
-```sh
-npm create astro@latest -- --template basics
+> Where code meets caffeine ☕
+
+![Chris Nowicki's Personal Website](public/og-image.png)
+
+## What's This?
+
+My little slice of the internet, built with modern tech and way too much coffee. This portfolio and blog is where I share my tech adventures, coding exploits, and occasional wisdom about avoiding burnout (something I learned the hard way).
+
+## Tech Stack
+
+- **Framework**: Astro 5.x (SSR) - because sometimes you just want things to be fast without the client-side drama
+- **UI Components**: Svelte 5.x - for when things need to get interactive
+- **Styling**: Tailwind CSS v4 - because writing actual CSS in 2026 is for masochists
+- **Content**: Markdown with auto-linking headings - keeping it simple and semantic
+- **Deployment**: Vercel - where websites go to live their best lives
+
+## Running Locally
+
+Assuming you have pnpm installed and enough coffee in your system:
+
+```bash
+# Clone this repo
+git clone https://github.com/chris-nowicki/chrisnowicki.dev.git
+
+# Install dependencies
+pnpm install
+
+# Start the development server
+pnpm dev
+
+# Build for production
+pnpm build
+
+# Preview the production build
+pnpm preview
+
+# Run tests (if you're into that sort of thing)
+pnpm test
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
+## Project Structure
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-│   └── favicon.svg
-├── src/
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
+```
+src/
+├── assets/        # Images and icons
+├── components/    # Astro and Svelte components
+├── content/       # Blog posts in Markdown
+├── data/          # Static data files
+├── layouts/       # Layout templates
+├── lib/           # Core library files
+├── pages/         # Astro page routes
+├── styles/        # Global styles
+└── utils/         # Utility functions
 ```
 
-To learn more about the folder structure of an Astro project, refer to [our guide on project structure](https://docs.astro.build/en/basics/project-structure/).
+## Key Features
 
-## 🧞 Commands
+- ⚡ **Blazing fast** - because nobody likes waiting
+- 🧠 **Minimal design** - focused on content without distractions
+- ✍️ **Blog with Markdown** - because writing HTML by hand is cruel
+- 🖼️ **Cloudinary integration** - for optimized OG images
+- 🚀 **SSR on Vercel** - for that sweet SEO juice
+- ☕ **Coffee-powered development** - "Oh, and coffee. Lots of coffee."
 
-All commands are run from the root of the project, from a terminal:
+## Contact & Socials
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
+- 🐦 [Twitter/X](https://twitter.com/iamwix)
+- 💼 [LinkedIn](https://www.linkedin.com/in/chris-nowicki/)
+- 🧑‍💻 [GitHub](https://github.com/chris-nowicki)
+- 📺 [Twitch](https://www.twitch.tv/chriswix)
 
-## 👀 Want to learn more?
+## License
 
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+Feel free to take inspiration from this site, but please don't directly copy it. If you do use any code, a link back would be appreciated but not required. Creating a unique online presence is always better than copying someone else's!
+
+Built with love by [Chris Nowicki](https://chrisnowicki.dev) — Developer Experience Engineer, coffee enthusiast, and tech tinkerer who's just trying to make the internet a little better, one commit at a time.


### PR DESCRIPTION
## Summary
- Replaces the default Astro starter README with a personalized, witty README
- Adds comprehensive documentation about the site's tech stack, features, and setup
- Includes project structure, running instructions, and social links
- Matches the author's personality and style with coffee references and humor

This PR provides visitors with a clear understanding of the project while showcasing the developer's personality and tech interests.