### PR TITLE
fix(blog): use process.env for runtime env var in view tracking

### DIFF
--- a/src/pages/api/views/[slug].ts
+++ b/src/pages/api/views/[slug].ts
@@ -63,7 +63,8 @@ export const POST: APIRoute = async ({ params }) => {
   }
 
   // Skip view tracking if not enabled (protects production data during dev/preview)
-  if (import.meta.env.ENABLE_VIEW_TRACKING !== 'true') {
+  // Use process.env for runtime environment variables in Vercel serverless functions
+  if (process.env.ENABLE_VIEW_TRACKING !== 'true') {
     return new Response(
       JSON.stringify({ slug, view_count: 0, tracking_disabled: true }),
       {


### PR DESCRIPTION
## Summary

- Fix blog view counts not incrementing in production by using `process.env` instead of `import.meta.env` for the `ENABLE_VIEW_TRACKING` environment variable
- `import.meta.env` is populated at build time, but Vercel runtime environment variables need to be accessed via `process.env` in serverless functions

## Test plan

- [ ] Deploy to Vercel preview environment
- [ ] Verify `ENABLE_VIEW_TRACKING=true` is set in Vercel production environment
- [ ] Visit a blog post and confirm view count increments in the database
- [ ] Check API response from `/api/views/[slug]` no longer returns `tracking_disabled: true`