### PR TITLE
fix(blog): use process.env for Supabase service role key

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -13,7 +13,9 @@ export { invalidateCache, invalidateAllCache }
 
 const supabaseUrl = import.meta.env.PUBLIC_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.PUBLIC_SUPABASE_ANON_KEY
-const supabaseServiceRoleKey = import.meta.env.SUPABASE_SERVICE_ROLE_KEY
+// Use process.env for non-PUBLIC env vars in Vercel serverless functions
+// import.meta.env only works at build time for non-PUBLIC vars
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {
   console.warn(

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -31,7 +31,8 @@ const postSlug = post.id
 // Fetch initial view count server-side for immediate display
 const initialViewCount = await getViewCount(postSlug)
 // Check if view tracking is enabled (only true in production)
-const trackingEnabled = import.meta.env.ENABLE_VIEW_TRACKING === 'true'
+// Use process.env for runtime env vars in Vercel serverless/SSR context
+const trackingEnabled = process.env.ENABLE_VIEW_TRACKING === 'true'
 ---
 
 <PageLayout


### PR DESCRIPTION
## Summary

- Fix `SUPABASE_SERVICE_ROLE_KEY` in `supabase.ts` to use `process.env` instead of `import.meta.env`
- Fix `ENABLE_VIEW_TRACKING` in `[slug].astro` to use `process.env` for SSR context
- `import.meta.env` only works at build time for non-PUBLIC env vars, causing `supabaseServer` to be `null` at runtime in Vercel serverless functions

This is a follow-up to PR #54 which fixed the API route but missed these two files.

## Test plan

- [ ] Deploy to Vercel and verify view counts increment in production
- [ ] Check Vercel function logs for any Supabase connection errors