### PR TITLE
fix(blog): fetch fresh view count before incrementing to prevent stale flash

### DIFF
--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -78,37 +78,34 @@ const trackingEnabled = process.env.ENABLE_VIEW_TRACKING === 'true'
     }
 
     const postSlug = viewCountElement.getAttribute('data-slug')
+    if (!postSlug) return
+
     const trackingEnabled =
       viewCountElement.getAttribute('data-tracking-enabled') === 'true'
 
-    // Skip tracking if not enabled - keep showing the initial count from server
-    if (!postSlug || !trackingEnabled) {
-      return
-    }
-
-    const initialCount = Number.parseInt(
-      viewCountElement.getAttribute('data-initial-count') ?? '0',
-      10
-    )
-
     try {
-      // Increment view count - POST already returns the updated count
-      const response = await fetch(`/api/views/${postSlug}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      })
-
-      if (response.ok) {
-        const data = await response.json()
-        viewCountElement.textContent = formatViewCount(
-          data.view_count ?? initialCount
-        )
+      // Step 1: GET fresh count to fix stale static value
+      const getResponse = await fetch(`/api/views/${postSlug}`)
+      if (getResponse.ok) {
+        const getData = await getResponse.json()
+        viewCountElement.textContent = formatViewCount(getData.view_count ?? 0)
       }
-      // Silently fail - keep existing count if tracking fails
+
+      // Step 2: POST to increment (only if tracking enabled)
+      if (trackingEnabled) {
+        const postResponse = await fetch(`/api/views/${postSlug}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+        if (postResponse.ok) {
+          const postData = await postResponse.json()
+          viewCountElement.textContent = formatViewCount(
+            postData.view_count ?? 0
+          )
+        }
+      }
     } catch (error) {
-      // Silently fail - don't break the page if view tracking fails
+      // Silently fail - keep existing count if view tracking fails
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix view count synchronization issue where statically generated blog posts displayed stale build-time view counts
- Now fetches fresh count via GET before POSTing to increment, ensuring smooth transitions (e.g., 7 → 8 instead of 5 → 8)

## Problem

Individual blog posts use `prerender = true` (static generation), so the `initialViewCount` was baked in at build time. When visiting from the SSR index page (which shows fresh counts), users saw a jarring flash from the stale static value to the newly incremented count.

## Solution

Updated the client-side `trackView()` function to:
1. GET the current view count first (CDN-cached, fast)
2. Update the display with the fresh value
3. POST to increment (if tracking enabled)
4. Update the display with the incremented value

## Test plan

- [ ] Deploy to preview environment
- [ ] Visit blog index page, note view count for a post (e.g., 7)
- [ ] Click through to the individual post
- [ ] Verify count shows 7 briefly, then increments to 8 (no flash from stale value)