### PR TITLE
refactor(blog): use Svelte await block for view counter

### DIFF
--- a/src/components/Svelte/ViewCounter.svelte
+++ b/src/components/Svelte/ViewCounter.svelte
@@ -1,38 +1,42 @@
 <script lang="ts">
-  import { onMount } from 'svelte'
-
   export let slug: string
-  export let initialCount: number = 0
   export let trackingEnabled: boolean = false
 
-  let viewCount = initialCount
-
-  onMount(async () => {
-    try {
-      // Step 1: GET fresh count to fix stale static value
-      const getResponse = await fetch(`/api/views/${slug}`)
-      if (getResponse.ok) {
-        const getData = await getResponse.json()
-        viewCount = getData.view_count ?? 0
-      }
-
-      // Step 2: POST to increment (only if tracking enabled)
-      if (trackingEnabled) {
-        const postResponse = await fetch(`/api/views/${slug}`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        })
-        if (postResponse.ok) {
-          const postData = await postResponse.json()
-          viewCount = postData.view_count ?? viewCount
-        }
-      }
-    } catch (error) {
-      // Silently fail - keep existing count if view tracking fails
+  async function fetchAndTrackViews() {
+    // GET fresh count
+    const getResponse = await fetch(`/api/views/${slug}`)
+    let viewCount = 0
+    if (getResponse.ok) {
+      const getData = await getResponse.json()
+      viewCount = getData.view_count ?? 0
     }
-  })
+
+    // POST to increment if tracking enabled
+    if (trackingEnabled) {
+      const postResponse = await fetch(`/api/views/${slug}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+      if (postResponse.ok) {
+        const postData = await postResponse.json()
+        viewCount = postData.view_count ?? viewCount
+      }
+    }
+
+    return viewCount
+  }
+
+  let viewsPromise = fetchAndTrackViews()
 </script>
 
-<span class="inline-flex items-center">
-  {viewCount.toLocaleString('en-US')}
-</span>
+{#await viewsPromise}
+  <!-- Show nothing while loading -->
+{:then viewCount}
+  {#if viewCount > 0}
+    <span class="inline-flex items-center">
+      | {viewCount.toLocaleString('en-US')} views
+    </span>
+  {/if}
+{:catch}
+  <!-- Show nothing on error -->
+{/await}

--- a/src/pages/api/views/[slug].ts
+++ b/src/pages/api/views/[slug].ts
@@ -1,10 +1,10 @@
 import type { APIRoute } from 'astro'
 import { supabaseServer, getViewCount, invalidateCache } from '@/lib/supabase'
 
-// Cache headers for CDN caching (shared across all serverless instances)
+// No CDN caching for individual slug lookups - we want fresh counts
 const CACHE_HEADERS = {
   'Content-Type': 'application/json',
-  'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
+  'Cache-Control': 'no-store',
 }
 
 // No-cache headers for write operations

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -7,7 +7,6 @@ import generateOgImageUrl from '@/utils/og-image'
 import { readingTime } from '@/utils/reading-time'
 import { Image } from 'astro:assets'
 import { getCollection, render } from 'astro:content'
-import { getViewCount } from '@/lib/supabase'
 
 export const prerender = true
 
@@ -29,8 +28,6 @@ const ogImageUrl = generateOgImageUrl({
 })
 
 const postSlug = post.id
-// Fetch initial view count server-side for immediate display
-const initialViewCount = await getViewCount(postSlug)
 // Check if view tracking is enabled (only true in production)
 // Use import.meta.env for local dev, process.env for Vercel runtime
 const trackingEnabled = 
@@ -47,12 +44,11 @@ const trackingEnabled =
       <header class="mb-8 flex flex-col gap-2">
         <h1 class="mt-8 text-xl font-bold sm:text-4xl">{post.data.title}</h1>
         <span class="text-muted-foreground flex items-center gap-2 text-sm"
-          >{postDate} | {postReadTime} | <ViewCounter
+          >{postDate} | {postReadTime} <ViewCounter
             client:load
             slug={postSlug}
-            initialCount={initialViewCount}
             trackingEnabled={trackingEnabled}
-          /> views</span
+          /></span
         >
         {
           post.data.image && (

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -74,12 +74,14 @@ const ogImageUrl = generateOgImageUrl({
                 <p class="text-muted-foreground">{post.data.description}</p>
                 <div class="mt-1 font-mono text-sm">
                   <span class="text-sm tracking-tight text-muted-foreground">
-                    {readingTime(post.rendered?.html ?? '')} ·
+                    {readingTime(post.rendered?.html ?? '')}
                   </span>
-                  {post.data.category && <span>{post.data.category}</span>}
-                  <span class="text-sm tracking-tight text-muted-foreground">
-                    {' '}· {formatViewCount(viewCounts[post.id] ?? 0)} views
-                  </span>
+                  {post.data.category && <span> · {post.data.category}</span>}
+                  {(viewCounts[post.id] ?? 0) > 0 && (
+                    <span class="text-sm tracking-tight text-muted-foreground">
+                      {' '}· {formatViewCount(viewCounts[post.id])} views
+                    </span>
+                  )}
                 </div>
               </a>
             ))}


### PR DESCRIPTION
## Summary

- Refactor ViewCounter to use Svelte's `{#await}` block instead of `onMount` pattern for cleaner async handling
- Remove stale `initialCount` from static generation - now fetches fresh counts client-side
- Hide view counts during loading state and when count is 0 (instead of showing stale/zero values)
- Remove CDN caching from individual view API endpoint for fresh counts on blog posts
- Blog index page retains server-side caching for efficient bulk fetches

## Changes

| File | Change |
|------|--------|
| `ViewCounter.svelte` | Replace `onMount` with `{#await}` block, remove `initialCount` prop |
| `[slug].astro` | Remove server-side view count fetch and `initialCount` prop |
| `index.astro` | Conditionally hide views when count is 0 |
| `api/views/[slug].ts` | Change Cache-Control from `s-maxage=60` to `no-store` |

## Test plan

- [ ] Navigate to a blog post and verify view count loads after brief delay (no stale count flash)
- [ ] Verify view count is hidden when 0 (new posts or errors)
- [ ] Verify blog index page still shows view counts correctly
- [ ] Verify view count increments on page load in production