### PR TITLE
fix: Configure image service for Cloudflare and suppress Vite warnings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,9 @@ export default defineConfig({
   vite: {
     // @ts-ignore - Tailwind Vite plugin type compatibility
     plugins: [tailwindcss()],
+    ssr: {
+      external: ['node:async_hooks', 'node:crypto'],
+    },
   },
 
   integrations: [sitemap(), svelte()],
@@ -41,4 +44,9 @@ export default defineConfig({
   adapter: cloudflare(),
   output: 'server',
   prefetch: true,
+  image: {
+    service: {
+      entrypoint: 'astro/assets/services/sharp',
+    },
+  },
 })


### PR DESCRIPTION
## Changes

This PR fixes the Cloudflare adapter warning about sharp not being supported at runtime and suppresses Vite warnings for Node.js built-in modules.

### Image Service Configuration
- Added `image.service.entrypoint: 'astro/assets/services/sharp'` to enable build-time image optimization
- Images on prerendered pages are now optimized with sharp during build time
- SSR pages will use a fallback image service at runtime (as expected)

### Vite Warning Suppression
- Added `ssr.external` configuration to explicitly externalize `node:async_hooks` and `node:crypto`
- Suppresses Vite warnings about automatically externalized Node.js built-in modules

## Testing
- ✅ Build completes successfully
- ✅ Images are optimized at build time (verified in build output)
- ✅ Vite warnings for Node.js modules are suppressed
- ⚠️ Cloudflare adapter warning still appears (informational only, functionality works correctly)

## Notes
The Cloudflare adapter warning about sharp is informational and appears before the image service config is evaluated. The functionality works correctly - images are optimized at build time as expected.