### PR TITLE
refactor(ui): remove shadow hover effects for design consistency

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -38,7 +38,7 @@ import { STATUS, socialLinks } from '@/lib/site'
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Visit the Commerce website"
-          class="inline-flex items-center gap-2.5 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow-sm transition-all hover:border-slate-300 hover:shadow-md"
+          class="inline-flex items-center gap-2.5 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow-sm transition-all hover:border-slate-300"
         >
           <span class="group/status relative flex h-2 w-2 cursor-help">
             <span class:list={[

--- a/src/lib/buttonVariants.ts
+++ b/src/lib/buttonVariants.ts
@@ -2,9 +2,9 @@ const baseStyles =
   'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all duration-200 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 active:scale-[0.98]'
 
 const variants = {
-  default: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md',
+  default: 'bg-primary text-primary-foreground shadow-sm hover:bg-primary/90',
   outline:
-    'border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground hover:shadow-md',
+    'border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground',
 } as const
 
 const sizes = {


### PR DESCRIPTION
## Summary
- Remove `hover:shadow-md` from "Working at Commerce" pill in Hero section
- Remove `hover:shadow-md` from `default` and `outline` button variants
- Aligns hover effects with site's design patterns (border/background color changes instead of shadow elevation)

## Test plan
- [ ] Run `pnpm dev` and check Hero section
- [ ] Hover over "Working at Commerce" pill - should only change border color
- [ ] Hover over "Buy Me A Coffee" button - should change background/text color only
- [ ] Hover over "Contact Me" button - should change background color only
- [ ] Verify hover effects feel consistent with other elements on the page

🤖 Generated with [Claude Code](https://claude.ai/code)