### PR TITLE
docs: update Svelte references to React across documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ pnpm test <file>      # Run specific test file
 ## Tech Stack
 
 - **Astro 5.x** with SSR (Server-Side Rendering) on Vercel
-- **Svelte 5.x** for interactive components
+- **React 19.x** with `framer-motion` for interactive components
 - **Tailwind CSS v4** with Vite plugin
 - **TypeScript** in strict mode
 - **Convex** for real-time blog view tracking
@@ -27,12 +27,12 @@ pnpm test <file>      # Run specific test file
 
 - **Static pages**: Home page and individual blog posts use `prerender = true`
 - **SSR pages**: Blog index uses `prerender = false` to fetch dynamic view counts
-- **Client-side interactivity**: Svelte components hydrate on the client for real-time features
+- **Client-side interactivity**: React components hydrate on the client for real-time features
 
 ### Component Organization
 
 - **Astro components** (`.astro`) for static/server-rendered content
-- **Svelte components** (`.svelte`) in `src/components/Svelte/` for client-side interactivity
+- **React components** (`.tsx`) in `src/components/React/` for client-side interactivity
 - Props interfaces always named `Props` with optional fields having defaults
 
 ### Data Layer
@@ -52,9 +52,9 @@ Functions in `convex/blogViews.ts`:
 - `getViewCount(slug)` / `getViewCounts(slugs)` - Queries
 - `incrementViewCount(slug)` - Mutation (upserts)
 
-Client setup in `src/lib/convex.ts`:
-- `convexClient` - Browser client for real-time subscriptions (Svelte)
-- `convexHttpClient` - HTTP client for SSR (Astro)
+Client setup:
+- `src/lib/convex.ts` - `getConvexHttpClient()` async HTTP client for SSR (Astro)
+- `src/lib/convex-client.ts` - `initConvexClient()` async browser client for real-time subscriptions (React)
 - Gracefully degrades if `PUBLIC_CONVEX_URL` not set
 
 ## Code Style
@@ -70,7 +70,7 @@ Client setup in `src/lib/convex.ts`:
 
 ### Naming
 
-- **Files**: `kebab-case.ts` for utilities, `PascalCase.astro/svelte` for components
+- **Files**: `kebab-case.ts` for utilities, `PascalCase.astro/tsx` for components
 - **Variables/Functions**: camelCase
 - **Constants**: UPPER_SNAKE_CASE
 - **Types**: PascalCase
@@ -85,7 +85,8 @@ Client setup in `src/lib/convex.ts`:
 ## Key Files
 
 - `src/lib/site.ts` - Site metadata, navigation links, social links
-- `src/lib/convex.ts` - Convex client configuration
+- `src/lib/convex.ts` - Convex HTTP client for SSR
+- `src/lib/convex-client.ts` - Convex browser client for React components
 - `src/content.config.ts` - Content collection schemas
 - `src/utils/utils.ts` - `cn()` utility, `formatDate()`, `formatViewCount()`
 - `src/utils/blog-helpers.ts` - Blog post fetching and sorting

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ My little slice of the internet, built with modern tech and way too much coffee.
 ## Tech Stack
 
 - **Framework**: Astro 5.x (SSR) - because sometimes you just want things to be fast without the client-side drama
-- **UI Components**: Svelte 5.x - for when things need to get interactive
+- **UI Components**: React 19.x - for when things need to get interactive
 - **Styling**: Tailwind CSS v4 - because writing actual CSS in 2026 is for masochists
 - **Database**: Convex - real-time view tracking with WebSocket subscriptions
 - **Content**: Markdown with auto-linking headings - keeping it simple and semantic
@@ -46,7 +46,7 @@ pnpm test
 ```
 src/
 ├── assets/        # Images and icons
-├── components/    # Astro and Svelte components
+├── components/    # Astro and React components
 ├── content/       # Blog posts in Markdown
 ├── data/          # Static data files
 ├── layouts/       # Layout templates


### PR DESCRIPTION
## Summary
- Replace all Svelte 5.x references with React 19.x in CLAUDE.md, README.md, and AGENTS.md
- Update Convex client documentation to reflect the two-file setup (`convex.ts` for SSR, `convex-client.ts` for React components)
- Replace Svelte component example in AGENTS.md with React functional component using `useState`/`useEffect`

## Test plan
- [x] Verified zero remaining Svelte references in all three files
- [x] `pnpm build` passes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)