### PR TITLE
fix(spotify): add CDN caching to prevent rate limiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ pnpm test <file>      # Run specific test file
 
 ## Tech Stack
 
-- **Astro 5.x** with SSR (Server-Side Rendering) on Vercel
+- **Astro 5.x** with SSR (Server-Side Rendering) on Cloudflare
 - **React 19.x** with `framer-motion` for interactive components
 - **Tailwind CSS v4** with Vite plugin
 - **TypeScript** in strict mode

--- a/src/pages/api/spotify.ts
+++ b/src/pages/api/spotify.ts
@@ -2,7 +2,11 @@ import type { APIRoute } from 'astro'
 
 export const prerender = false
 
-export const GET: APIRoute = async ({ locals }) => {
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=30',
+}
+
+export const GET: APIRoute = async () => {
   const clientId = import.meta.env.SPOTIFY_CLIENT_ID
   const clientSecret = import.meta.env.SPOTIFY_CLIENT_SECRET
   const refreshToken = import.meta.env.SPOTIFY_REFRESH_TOKEN
@@ -39,13 +43,16 @@ export const GET: APIRoute = async ({ locals }) => {
   if (currentRes.status === 200) {
     const data = await currentRes.json()
     if (data?.item) {
-      return Response.json({
-        isPlaying: data.is_playing,
-        title: data.item.name,
-        artist: data.item.artists.map((a: { name: string }) => a.name).join(', '),
-        albumArt: data.item.album.images[0]?.url ?? data.item.album.images[2]?.url,
-        songUrl: data.item.external_urls.spotify,
-      })
+      return Response.json(
+        {
+          isPlaying: data.is_playing,
+          title: data.item.name,
+          artist: data.item.artists.map((a: { name: string }) => a.name).join(', '),
+          albumArt: data.item.album.images[0]?.url ?? data.item.album.images[2]?.url,
+          songUrl: data.item.external_urls.spotify,
+        },
+        { headers: CACHE_HEADERS },
+      )
     }
   }
 
@@ -66,11 +73,14 @@ export const GET: APIRoute = async ({ locals }) => {
     return Response.json({ isPlaying: false, title: null })
   }
 
-  return Response.json({
-    isPlaying: false,
-    title: track.name,
-    artist: track.artists.map((a: { name: string }) => a.name).join(', '),
-    albumArt: track.album.images[0]?.url ?? track.album.images[2]?.url,
-    songUrl: track.external_urls.spotify,
-  })
+  return Response.json(
+    {
+      isPlaying: false,
+      title: track.name,
+      artist: track.artists.map((a: { name: string }) => a.name).join(', '),
+      albumArt: track.album.images[0]?.url ?? track.album.images[2]?.url,
+      songUrl: track.external_urls.spotify,
+    },
+    { headers: CACHE_HEADERS },
+  )
 }


### PR DESCRIPTION
## Summary
- Spotify's `recently-played` endpoint was returning **429 Too Many Requests** because each visitor's poll triggered raw API calls to Spotify
- Added `Cache-Control: public, s-maxage=60, stale-while-revalidate=30` headers so Cloudflare's CDN caches responses, reducing Spotify API calls to ~1/minute regardless of visitor count
- Fixed CLAUDE.md to reference Cloudflare instead of Vercel

## Test plan
- [ ] Deploy to preview and verify `/api/spotify` returns `Cache-Control` header
- [ ] Confirm Spotify widget loads track data on the homepage
- [ ] Check response headers show CDN cache hits on subsequent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)