### PR TITLE
fix: restore PageFrame vertical lines across full page height

### DIFF
--- a/src/components/PageFrame.astro
+++ b/src/components/PageFrame.astro
@@ -2,7 +2,7 @@
 import FramePlus from './FramePlus.astro'
 ---
 
-<div class="pointer-events-none absolute inset-0 z-0 hidden md:block" aria-hidden="true">
+<div class="pointer-events-none absolute inset-0 z-10 hidden md:block" aria-hidden="true">
   <div
     class="absolute top-0 bottom-0 border-l border-dashed border-border"
     style="left: calc(50% - 28rem - 1.5rem);">

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -31,7 +31,7 @@ const fadeNoInitial = {
     />
   </head>
   <body>
-    <div class="relative overflow-x-hidden">
+    <div class="relative overflow-x-clip">
       <PageFrame />
       <NavBar />
       <main transition:animate={fadeNoInitial}>


### PR DESCRIPTION
## Summary
- Fix decorative vertical dashed lines from `PageFrame` not rendering below the first viewport-height of the page
- Change wrapper `overflow-x-hidden` → `overflow-x-clip` in `PageLayout.astro` to prevent CSS overflow-y cascade that clamped the wrapper height
- Bump `PageFrame` z-index from `z-0` to `z-10` to ensure lines paint above `<main>`'s view-transition stacking context

## Root Cause
Per CSS spec, setting `overflow-x: hidden` while `overflow-y` is `visible` causes `overflow-y` to compute to `auto`. This turned the wrapper into a scroll container, and combined with `body { height: 100%; display: flex }`, flexbox shrinking clamped the wrapper to viewport height. `PageFrame`'s `absolute inset-0` then only covered one screenful.

`overflow-x: clip` clips identically to `hidden` but does **not** trigger the `overflow-y` override or create a scroll container.

## Test plan
- [x] Verify vertical dashed lines are visible alongside all sections (hero, blog posts, bento cards, footer) at viewport >= 960px
- [x] Verify horizontal dashed separators and FramePlus "+" marks still render correctly
- [x] Verify mobile nav overlay still works
- [x] Verify page transitions still animate between routes
- [x] Verify no horizontal scrollbar appears (SectionSeparator clipping still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)