### PR TITLE
feat: cache spotify now-playing with KV + cache api

### DIFF
--- a/src/components/React/SpotifyBentoCard.tsx
+++ b/src/components/React/SpotifyBentoCard.tsx
@@ -72,7 +72,7 @@ export default function SpotifyBentoCard() {
     }
 
     fetchTrack()
-    const interval = setInterval(fetchTrack, 90_000)
+    const interval = setInterval(fetchTrack, 60_000)
 
     return () => {
       cancelled = true

--- a/src/pages/api/spotify.ts
+++ b/src/pages/api/spotify.ts
@@ -1,22 +1,32 @@
 import type { APIRoute } from 'astro'
+import { env } from 'cloudflare:workers'
 
 export const prerender = false
 
-export const GET: APIRoute = async ({ locals }) => {
+const KV_TOKEN_KEY = 'spotify:access_token'
+const TOKEN_TTL_SECONDS = 3300
+const RESPONSE_TTL_SECONDS = 30
+const NO_TRACK = { isPlaying: false, title: null }
+
+type Track = {
+  isPlaying: boolean
+  title: string
+  artist: string
+  albumArt: string
+  songUrl: string
+}
+type TrackPayload = Track | typeof NO_TRACK
+
+async function refreshAccessToken(): Promise<string | null> {
   const clientId = import.meta.env.SPOTIFY_CLIENT_ID
   const clientSecret = import.meta.env.SPOTIFY_CLIENT_SECRET
   const refreshToken = import.meta.env.SPOTIFY_REFRESH_TOKEN
+  if (!clientId || !clientSecret || !refreshToken) return null
 
-  if (!clientId || !clientSecret || !refreshToken) {
-    return Response.json({ isPlaying: false, title: null })
-  }
-
-  // Exchange refresh token for access token
-  const basicAuth = btoa(`${clientId}:${clientSecret}`)
-  const tokenRes = await fetch('https://accounts.spotify.com/api/token', {
+  const res = await fetch('https://accounts.spotify.com/api/token', {
     method: 'POST',
     headers: {
-      Authorization: `Basic ${basicAuth}`,
+      Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
       'Content-Type': 'application/x-www-form-urlencoded',
     },
     body: new URLSearchParams({
@@ -24,53 +34,113 @@ export const GET: APIRoute = async ({ locals }) => {
       refresh_token: refreshToken,
     }).toString(),
   })
+  if (!res.ok) return null
 
-  if (!tokenRes.ok) {
-    return Response.json({ isPlaying: false, title: null })
-  }
-
-  const { access_token: accessToken } = await tokenRes.json()
-
-  // Try currently playing first
-  const currentRes = await fetch('https://api.spotify.com/v1/me/player/currently-playing', {
-    headers: { Authorization: `Bearer ${accessToken}` },
+  const { access_token } = (await res.json()) as { access_token: string }
+  await env.SESSION.put(KV_TOKEN_KEY, access_token, {
+    expirationTtl: TOKEN_TTL_SECONDS,
   })
+  return access_token
+}
 
-  if (currentRes.status === 200) {
-    const data = await currentRes.json()
+async function getAccessToken(): Promise<string | null> {
+  return (await env.SESSION.get(KV_TOKEN_KEY)) ?? refreshAccessToken()
+}
+
+async function fetchSpotifyTrack(
+  token: string,
+): Promise<{ status: number; payload: TrackPayload }> {
+  const current = await fetch(
+    'https://api.spotify.com/v1/me/player/currently-playing',
+    { headers: { Authorization: `Bearer ${token}` } },
+  )
+  if (current.status === 401) return { status: 401, payload: NO_TRACK }
+  if (current.status === 200) {
+    const data = (await current.json()) as {
+      is_playing: boolean
+      item?: {
+        name: string
+        artists: { name: string }[]
+        album: { images: { url: string }[] }
+        external_urls: { spotify: string }
+      }
+    }
     if (data?.item) {
-      return Response.json({
-        isPlaying: data.is_playing,
-        title: data.item.name,
-        artist: data.item.artists.map((a: { name: string }) => a.name).join(', '),
-        albumArt: data.item.album.images[0]?.url ?? data.item.album.images[2]?.url,
-        songUrl: data.item.external_urls.spotify,
-      })
+      return {
+        status: 200,
+        payload: {
+          isPlaying: data.is_playing,
+          title: data.item.name,
+          artist: data.item.artists.map((a) => a.name).join(', '),
+          albumArt:
+            data.item.album.images[0]?.url ?? data.item.album.images[2]?.url,
+          songUrl: data.item.external_urls.spotify,
+        },
+      }
     }
   }
 
-  // Fall back to recently played
-  const recentRes = await fetch(
+  const recent = await fetch(
     'https://api.spotify.com/v1/me/player/recently-played?limit=1',
-    { headers: { Authorization: `Bearer ${accessToken}` } },
+    { headers: { Authorization: `Bearer ${token}` } },
   )
+  if (recent.status === 401) return { status: 401, payload: NO_TRACK }
+  if (!recent.ok) return { status: recent.status, payload: NO_TRACK }
 
-  if (!recentRes.ok) {
-    return Response.json({ isPlaying: false, title: null })
+  const recentData = (await recent.json()) as {
+    items?: {
+      track: {
+        name: string
+        artists: { name: string }[]
+        album: { images: { url: string }[] }
+        external_urls: { spotify: string }
+      }
+    }[]
   }
-
-  const recentData = await recentRes.json()
   const track = recentData?.items?.[0]?.track
+  if (!track) return { status: 200, payload: NO_TRACK }
 
-  if (!track) {
-    return Response.json({ isPlaying: false, title: null })
+  return {
+    status: 200,
+    payload: {
+      isPlaying: false,
+      title: track.name,
+      artist: track.artists.map((a) => a.name).join(', '),
+      albumArt: track.album.images[0]?.url ?? track.album.images[2]?.url,
+      songUrl: track.external_urls.spotify,
+    },
+  }
+}
+
+export const GET: APIRoute = async ({ request, locals }) => {
+  const cacheKey = new Request(
+    new URL('/api/spotify', request.url).toString(),
+    { method: 'GET' },
+  )
+  const cache = caches.default
+
+  const hit = await cache.match(cacheKey)
+  if (hit) return hit
+
+  let token = await getAccessToken()
+  if (!token) return Response.json(NO_TRACK)
+
+  let result = await fetchSpotifyTrack(token)
+  if (result.status === 401) {
+    await env.SESSION.delete(KV_TOKEN_KEY)
+    token = await refreshAccessToken()
+    if (!token) return Response.json(NO_TRACK)
+    result = await fetchSpotifyTrack(token)
   }
 
-  return Response.json({
-    isPlaying: false,
-    title: track.name,
-    artist: track.artists.map((a: { name: string }) => a.name).join(', '),
-    albumArt: track.album.images[0]?.url ?? track.album.images[2]?.url,
-    songUrl: track.external_urls.spotify,
+  const response = Response.json(result.payload, {
+    headers: {
+      'Cache-Control': `public, s-maxage=${RESPONSE_TTL_SECONDS}, max-age=10`,
+    },
   })
+
+  if (result.status === 200) {
+    locals.cfContext.waitUntil(cache.put(cacheKey, response.clone()))
+  }
+  return response
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,5 +7,8 @@
     // Astro Font API uses module-level async state that persists across requests.
     // Without this flag, the Workers runtime cancels cross-request promise continuations.
     "no_handle_cross_request_promise_resolution"
+  ],
+  "kv_namespaces": [
+    { "binding": "SESSION", "id": "fb2b9fb1c30c4ff0bbf284b01410e163" }
   ]
 }


### PR DESCRIPTION
## Summary

- **Why**: every `/api/spotify` poll refreshed the OAuth token and hit Spotify, despite tokens lasting ~1h and tracks changing every 90–210s. With N visitors, this scaled linearly with traffic.
- **Token cache (KV)**: stores the Spotify access token in the existing `SESSION` KV namespace (`spotify:` key prefix) with a 55min TTL. Removes the per-request token-refresh round trip.
- **Response cache (Cache API)**: caches the `/api/spotify` JSON at `caches.default` for 30s with `Cache-Control: public, s-maxage=30, max-age=10`. Regional, ~1ms reads, free. Bounds Spotify load to one call per 30s per edge region regardless of visitor count.
- **Bounded 401 recovery**: on a stale token, bust KV, refresh once, retry exactly once, then bail to a `NO_TRACK` response. Non-2xx responses are never written to the edge cache, so a transient Spotify outage can't get pinned for 30s.
- **Frontend poll**: 90s → 60s, calibrated against typical song length (1.5–3.5min) so worst-case staleness is ~90s and median is ~30s.
- **Adapter migration**: switched off the removed `locals.runtime.*` API (which now throws in `@astrojs/cloudflare` v13) to `import { env } from "cloudflare:workers"` for KV access and `locals.cfContext.waitUntil` for non-blocking cache writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)