### PR TITLE
fix: read spotify secrets from worker env, not import.meta.env

### DIFF
--- a/src/pages/api/spotify.ts
+++ b/src/pages/api/spotify.ts
@@ -18,9 +18,9 @@ type Track = {
 type TrackPayload = Track | typeof NO_TRACK
 
 async function refreshAccessToken(): Promise<string | null> {
-  const clientId = import.meta.env.SPOTIFY_CLIENT_ID
-  const clientSecret = import.meta.env.SPOTIFY_CLIENT_SECRET
-  const refreshToken = import.meta.env.SPOTIFY_REFRESH_TOKEN
+  const clientId = env.SPOTIFY_CLIENT_ID
+  const clientSecret = env.SPOTIFY_CLIENT_SECRET
+  const refreshToken = env.SPOTIFY_REFRESH_TOKEN
   if (!clientId || !clientSecret || !refreshToken) return null
 
   const res = await fetch('https://accounts.spotify.com/api/token', {


### PR DESCRIPTION
## Summary

- **Root cause**: `import.meta.env.SPOTIFY_*` is inlined by Vite at build time. Those values live only in `.env.local` on the dev machine — Cloudflare's build environment never sees them, so they were `undefined` at runtime in every deployed environment. The API short-circuited to `NO_TRACK` and the bento card hid itself.
- **Fix**: read `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` / `SPOTIFY_REFRESH_TOKEN` from `env` (`cloudflare:workers`), making them runtime secrets that flow through the same worker `env` binding as `SESSION`.
- **Local dev**: `.dev.vars` (gitignored) provides the values via Miniflare. No code changes needed locally beyond the env access pattern.
- **Production**: ⚠️ requires a one-time secrets setup before this fix takes effect. Run for each value:
  ```
  pnpm wrangler secret put SPOTIFY_CLIENT_ID
  pnpm wrangler secret put SPOTIFY_CLIENT_SECRET
  pnpm wrangler secret put SPOTIFY_REFRESH_TOKEN
  ```
  Or set them in the Cloudflare dashboard → Workers → portfolio → Settings → Variables and Secrets.
- **Why the previous PR's caching work was sound but invisible**: KV + Cache API were correctly wired, but the upstream token fetch never had credentials, so the cache layers never saw a 200. Once secrets are set, the full caching path lights up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)