### PR TITLE
refactor: homepage and UI cleanup

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,5 @@
 ---
-import { navLinks, SITE, socialLinks, STATUS } from '@/lib/site'
+import { navLinks, SITE, socialLinks } from '@/lib/site'
 
 import Container from './Container.astro'
 import FramePlus from './FramePlus.astro'
@@ -90,18 +90,11 @@ const builtWith = [
         </div>
       </div>
 
-      <div class="mt-10 flex flex-col items-center justify-between gap-3 border-t border-border pt-6 md:mt-16 md:flex-row md:pt-8">
+      <div class="mt-10 flex items-center justify-center border-t border-border pt-6 md:mt-16 md:pt-8">
         <p class="text-xs text-muted-foreground">
           &copy; {currentYear} {SITE.NAME}. Crafted with care &amp; <span class="inline-block transition-transform duration-200 hover:scale-125 cursor-default">☕</span>
         </p>
 
-        <div class="flex items-center gap-2 text-xs text-muted-foreground">
-          <span class="relative flex h-2 w-2">
-            <span class:list={["absolute inline-flex h-full w-full animate-ping rounded-full opacity-75", STATUS.available ? "bg-emerald-400" : "bg-red-400"]}></span>
-            <span class:list={["relative inline-flex h-2 w-2 rounded-full", STATUS.available ? "bg-emerald-500" : "bg-red-500"]}></span>
-          </span>
-          <span>{STATUS.message}</span>
-        </div>
       </div>
     </div>
   </Container>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,9 +2,6 @@
 import Image from 'astro/components/Image.astro'
 
 import Me from '@/assets/images/me.jpg'
-import { STATUS } from '@/lib/site'
-
-import Button from './Button.astro'
 ---
 
 <section class="relative mt-12 pb-8 md:mt-20">
@@ -32,33 +29,10 @@ import Button from './Button.astro'
         Developer Experience Engineer
       </p>
 
-      <!-- Status and company -->
-      <div class="hero-animate mt-3" style="--delay: 100ms">
-        <a
-          href="https://www.commerce.com"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Visit the Commerce website"
-          class="inline-flex items-center gap-2.5 rounded-full border border-border bg-background px-4 py-2 text-sm text-muted-foreground shadow-sm transition-all hover:border-ring"
-        >
-          <span class="group/status relative flex h-2 w-2 cursor-help">
-            <span class:list={[
-              "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
-              STATUS.available ? "bg-emerald-400" : "bg-amber-400"
-            ]}></span>
-            <span class:list={[
-              "relative inline-flex h-2 w-2 rounded-full",
-              STATUS.available ? "bg-emerald-500" : "bg-amber-500"
-            ]}></span>
-            <!-- Tooltip -->
-            <span class="pointer-events-none absolute bottom-full left-1/2 z-[100] mb-2 -translate-x-1/2 whitespace-nowrap rounded bg-primary px-2.5 py-1.5 text-xs text-primary-foreground opacity-0 shadow-lg transition-opacity duration-200 group-hover/status:opacity-100">
-              {STATUS.message}
-              <span class="absolute top-full left-1/2 -translate-x-1/2 border-[6px] border-transparent border-t-primary"></span>
-            </span>
-          </span>
-          <span>Working at <span class="font-semibold text-foreground">Commerce</span></span>
-        </a>
-      </div>
+      <!-- Company -->
+      <p class="hero-animate mt-1 text-sm text-muted-foreground" style="--delay: 130ms">
+        Working at <a href="https://www.commerce.com" target="_blank" rel="noopener noreferrer" class="font-semibold text-foreground hover:underline">Commerce</a>
+      </p>
 
       <!-- Bio -->
       <div class="hero-animate mt-8 max-w-lg space-y-4" style="--delay: 150ms">
@@ -78,36 +52,20 @@ import Button from './Button.astro'
         </blockquote>
       </div>
 
-      <!-- CTAs -->
-      <div class="hero-animate mt-10 flex flex-col gap-3 sm:flex-row sm:gap-4" style="--delay: 250ms">
-        <Button
-          href="/contact"
-          size="lg"
-          variant="default"
-          class="bg-primary text-primary-foreground text-center uppercase hover:bg-primary/90"
-        >
-          Contact Me
-        </Button>
-      </div>
     </div>
 
     <!-- Right: Photo -->
     <div class="hero-animate order-1 flex md:justify-center md:order-2" style="--delay: 100ms">
       <div class="flex flex-col items-center">
         <!-- Photo container -->
-        <div class="group relative">
-          <div class="h-36 w-36 overflow-hidden rounded-2xl border-4 border-background shadow-lg sm:h-44 sm:w-44 lg:h-52 lg:w-52">
-            <Image
-              src={Me}
-              alt="Photo of Chris Nowicki"
-              loading="eager"
-              width={220}
-              class="h-full w-full object-cover grayscale transition-all duration-500 group-hover:grayscale-0 group-hover:scale-105"
-            />
-          </div>
-
-          <!-- Hover ring effect -->
-          <div class="absolute inset-0 rounded-2xl border-2 border-transparent transition-all duration-500 group-hover:border-border group-hover:scale-110"></div>
+        <div class="h-36 w-36 overflow-hidden rounded-xl border border-border shadow-lg sm:h-44 sm:w-44 lg:h-52 lg:w-52">
+          <Image
+            src={Me}
+            alt="Photo of Chris Nowicki"
+            loading="eager"
+            width={220}
+            class="h-full w-full object-cover"
+          />
         </div>
 
       </div>

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -26,7 +26,6 @@ const postItems = posts.map((post) => ({
     <section class="mt-12 sm:mt-20">
       <header class="mb-6 flex flex-col md:flex-row md:items-center md:justify-between sm:mb-8">
         <div>
-          <span class="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">Latest</span>
           <h2 class="text-lg font-bold uppercase tracking-wide sm:text-2xl">Read my Latest Posts</h2>
         </div>
         <a

--- a/src/components/NowCard.astro
+++ b/src/components/NowCard.astro
@@ -1,0 +1,19 @@
+---
+const items = [
+  { label: 'Working on', value: 'Developer experience tooling at Commerce' },
+  { label: 'Learning', value: 'Cloudflare Workers & Agent Orchestration' },
+  { label: 'Reading', value: 'Dungeon Crawler Carl' },
+]
+---
+
+<div class="rounded-xl border bg-muted p-4 sm:p-5 md:p-6">
+  <h2 class="mb-4 text-base font-bold sm:text-lg">Now</h2>
+  <ul class="space-y-3">
+    {items.map(({ label, value }) => (
+      <li class="flex flex-col gap-0.5">
+        <span class="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">{label}</span>
+        <span class="text-sm text-foreground">{value}</span>
+      </li>
+    ))}
+  </ul>
+</div>

--- a/src/components/Speaking.astro
+++ b/src/components/Speaking.astro
@@ -37,20 +37,14 @@ const formatDate = (dateString: string) => {
             class="inline-flex items-center rounded-full border border-white bg-white px-2.5 py-1 text-xs font-bold uppercase tracking-wider text-black sm:px-3">
             Latest Talk
           </span>
-          {speaking.category.length > 0 && (
-            <span
-              class="inline-flex items-center rounded-full border border-white px-2.5 py-1 text-xs font-medium uppercase tracking-wider text-white sm:px-3">
-              {speaking.category[0]}
-            </span>
-          )}
         </div>
 
-        <h2 class="text-xl font-bold leading-tight tracking-tight break-words text-white sm:text-2xl md:text-3xl lg:text-4xl">
+        <h2 class="text-lg font-bold leading-tight tracking-tight break-words text-white sm:text-2xl md:text-3xl lg:text-4xl">
           {speaking.title}
         </h2>
 
         {speaking.description && (
-          <p class="text-sm text-white/70 sm:text-base md:text-lg">
+          <p class="line-clamp-2 text-sm text-white/70 sm:line-clamp-none sm:text-base md:text-lg">
             {speaking.description}
           </p>
         )}

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -1,6 +1,4 @@
 ---
-import { fade } from 'astro:transitions'
-
 import Footer from '@/components/Footer.astro'
 import Head from '@/components/Head.astro'
 import NavBar from '@/components/NavBar.astro'
@@ -16,10 +14,6 @@ interface Props {
 
 const { title, description, image } = Astro.props
 
-const fadeNoInitial = {
-  forwards: fade({ duration: '0.2s' }).forwards,
-  backwards: fade({ duration: '0.2s' }).backwards,
-}
 ---
 
 <!doctype html>
@@ -35,7 +29,7 @@ const fadeNoInitial = {
     <div class="relative flex min-h-screen flex-col shrink-0">
       <PageFrame />
       <NavBar />
-      <main class="flex-1" transition:animate={fadeNoInitial}>
+      <main class="flex-1">
         <slot />
       </main>
       <Footer />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,21 +1,15 @@
 ---
-import CategoryMenu from '@/components/CategoryMenu.astro'
 import Container from '@/components/Container.astro'
 import PageLayout from '@/layouts/PageLayout.astro'
 import { BLOG } from '@/lib/site'
-import { getAllPostCategories,getPostsByCategory } from '@/utils/blog-helpers'
+import { getBlogPosts } from '@/utils/blog-helpers'
 import generateOgImageUrl from '@/utils/og-image'
 import { readingTime } from '@/utils/reading-time'
 import { formatDate } from '@/utils/utils'
 
-export const prerender = false
+export const prerender = true
 
-const category = Astro.url.searchParams.get('category')
-
-const posts = await getPostsByCategory(category)
-const categories = await getAllPostCategories()
-
-const pathname = new URL(Astro.request.url).pathname.split('/')[1]
+const posts = await getBlogPosts()
 
 const ogImageUrl = generateOgImageUrl({
   header: `/${BLOG.TITLE.toUpperCase()}`,
@@ -38,10 +32,6 @@ const ogImageUrl = generateOgImageUrl({
           </h1>
         </div>
       </header>
-
-      <div>
-        <CategoryMenu categories={categories} currentCategory={category} pathname={pathname} />
-      </div>
 
       {
         posts.length > 0 ?
@@ -67,7 +57,6 @@ const ogImageUrl = generateOgImageUrl({
                   <span class="text-sm tracking-tight text-muted-foreground">
                     {readingTime(post.rendered?.html ?? '')}
                   </span>
-                  {post.data.category && <span> · {post.data.category.toLowerCase()}</span>}
                 </div>
               </a>
             ))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import ContactSection from '@/components/ContactSection.astro'
 import Container from '@/components/Container.astro'
 import Hero from '@/components/Hero.astro'
 import LatestPosts from '@/components/LatestPosts.astro'
+import NowCard from '@/components/NowCard.astro'
 import SpotifyBentoCard from '@/components/React/SpotifyBentoCard'
 import SectionSeparator from '@/components/SectionSeparator.astro'
 import Speaking from '@/components/Speaking.astro'
@@ -27,7 +27,7 @@ export const prerender = true
 
       <div class="flex min-w-0 flex-col gap-4">
         <Uses />
-        <ContactSection />
+        <NowCard />
       </div>
     </div>
   </Container>

--- a/src/pages/speaking.astro
+++ b/src/pages/speaking.astro
@@ -1,22 +1,14 @@
 ---
-import CategoryMenu from '@/components/CategoryMenu.astro'
 import Container from '@/components/Container.astro'
 import PageLayout from '@/layouts/PageLayout.astro'
 import { SPEAKING } from '@/lib/site'
 import generateOgImageUrl from '@/utils/og-image'
-import {
-  getAllSpeakingCategories,
-  getSpeakingData,
-} from '@/utils/speaking-helpers'
+import { getSpeakingData } from '@/utils/speaking-helpers'
 import { formatDate } from '@/utils/utils'
 
-export const prerender = false
-const category = Astro.url.searchParams.get('category')
+export const prerender = true
 
-const speaking = await getSpeakingData({ category })
-const categories = await getAllSpeakingCategories()
-
-const pathname = new URL(Astro.request.url).pathname.split('/')[1]
+const speaking = await getSpeakingData()
 
 const ogImageUrl = generateOgImageUrl({
   header: `/${SPEAKING.TITLE.toUpperCase()}`,
@@ -39,13 +31,6 @@ const ogImageUrl = generateOgImageUrl({
         </div>
       </header>
 
-      <div>
-        <CategoryMenu
-          categories={categories}
-          currentCategory={category}
-          pathname={pathname}
-        />
-      </div>
       <div>
         {
           speaking.map((talk) => (


### PR DESCRIPTION
## Summary

- **Hero**: removed Contact Me button, converted "Working at Commerce" pill to plain text, simplified photo to static rounded-xl with border (no hover animation)
- **Home page**: removed "Latest" label above blog posts; replaced ContactSection bento card with a new NowCard showing current focus areas
- **Blog & Speaking pages**: removed category filter UI; both pages flipped to `prerender = true` since dynamic rendering was only needed for category query params
- **Speaking bento card**: reduced mobile title size and clamped description to 2 lines on mobile to reduce card dominance
- **Footer**: removed "Available for speaking & collaborations" status indicator; centered copyright
- **Page transitions**: removed fade transition from `<main>` in PageLayout to fix white flash when navigating to blog posts

## Test plan

- [ ] Home page: no Contact Me button, photo is square with static border, no "Latest" label, NowCard visible in bento grid
- [ ] Navigate blog index → blog post in both light and dark mode — no white flash
- [ ] Blog page: no category filter UI, renders as static
- [ ] Speaking page: no category filter UI, renders as static
- [ ] Mobile (375px): Speaking bento card is less dominant, NowCard is compact
- [ ] Footer: no status indicator, copyright is centered
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)