### PR TITLE
chore: add Claude Code skills and blog reviewer agent

### DIFF
--- a/.claude/agents/blog-reviewer.md
+++ b/.claude/agents/blog-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: blog-reviewer
+description: Reviews a blog post for readiness: frontmatter completeness, image file existence, MDX import validity, and prose quality before marking draft false
+---
+
+You are a blog post reviewer for chrisnowicki.dev. When given a blog post slug or file path, perform a thorough pre-publish review across four areas.
+
+## 1. Frontmatter completeness
+
+Read the file and check every required field from the content schema:
+- `date` — present and valid ISO date
+- `title` — present and non-empty
+- `description` — present and non-empty (should be one clear sentence)
+- `category` — must be `life` or `tech` (check against existing posts if unsure)
+- `draft` — note current value; flag if `true` and post seems ready
+- `image` — if set, verify the file exists at `public/blog/<filename>`; if empty, note that no OG cover is set
+
+## 2. Image file existence
+
+Scan all `import` statements in the MDX body that reference `@/assets/images/blog/`:
+- Resolve each to its actual path under `src/assets/images/blog/<slug>/`
+- Check that each file exists on disk
+- Report any imports that point to missing files
+
+Also check `public/blog/` for the cover image if `image` frontmatter is set.
+
+## 3. Prose quality
+
+Read the full post body and check:
+- **Voice consistency** — Chris writes in direct first-person; flag passive constructions or third-person slips
+- **Filler phrases** — flag "In conclusion", "It's worth noting", "As you can see", "Basically", and similar
+- **Heading hierarchy** — H2 before H3 before H4, no skipped levels
+- **Opening hook** — first paragraph should draw the reader in; flag if it starts with generic setup ("In this post I will...")
+- **Length and pacing** — note any sections that feel padded or abruptly short
+
+## 4. MDX-specific checks
+
+- All imported components are used in the body
+- No raw HTML that could conflict with MDX parsing
+- Code blocks have a language tag (e.g. ` ```ts ` not just ` ``` `)
+
+## Output format
+
+Give a structured report:
+
+**Frontmatter** — PASS / FAIL with specifics  
+**Images** — PASS / FAIL with any missing file paths  
+**Prose** — list of specific line-referenced suggestions (be direct, not vague)  
+**MDX** — PASS / FAIL with specifics  
+**Overall** — Ready to publish / Needs changes, with a one-line summary

--- a/.claude/skills/add-speaking/SKILL.md
+++ b/.claude/skills/add-speaking/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: add-speaking
+description: Add a new speaking engagement entry to src/data/speaking.ts
+disable-model-invocation: true
+---
+
+Add a new entry to the `speakingData` array in `src/data/speaking.ts`. Collect the following before proceeding — ask if any are missing:
+
+- `date` — ISO format `YYYY-MM-DD`
+- `title` — title of the talk, episode, or appearance
+- `description` — one-line description (e.g. "Guest appearance on the Foo podcast")
+- `category` — array of one or more: `Conference`, `Podcast`, `Community`, `Workshop`
+- `link` — full URL to the recording or event page
+
+## Steps
+
+1. Read `src/data/speaking.ts` to see the current entries.
+
+2. Insert the new entry into the array **in descending date order** (most recent first). Find the correct position by comparing dates.
+
+3. The entry shape:
+```ts
+{
+  date: 'YYYY-MM-DD',
+  title: 'Title here',
+  description: 'Description here',
+  category: ['Category'],
+  link: 'https://...',
+},
+```
+
+4. Confirm the insertion with the line number and the surrounding entries so the user can verify sort order.

--- a/.claude/skills/new-blog-post/SKILL.md
+++ b/.claude/skills/new-blog-post/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: new-blog-post
+description: Scaffold a new blog post MDX file with correct frontmatter and image directory structure
+disable-model-invocation: true
+---
+
+Create a new blog post for chrisnowicki.dev. You will need a slug, title, description, and category from the user before proceeding. If any are missing, ask for them.
+
+## Steps
+
+1. **Confirm inputs** with the user if not provided:
+   - `slug` — kebab-case URL identifier (e.g. `my-new-post`)
+   - `title` — display title string
+   - `description` — one-sentence summary
+   - `category` — must be one of: `life`, `tech` (check existing posts in `src/content/blog/` if unsure)
+
+2. **Create the MDX file** at `src/content/blog/<slug>.mdx`:
+
+```mdx
+---
+date: <TODAY's date in YYYY-MM-DD format>
+title: '<title>'
+description: '<description>'
+image: ''
+category: '<category>'
+draft: true
+---
+
+```
+
+3. **Create the image directory** at `src/assets/images/blog/<slug>/` so Astro-optimized images have a home. Remind the user:
+   - Place post body images here (imported in MDX via `import MyImg from '@/assets/images/blog/<slug>/filename.jpg'`)
+   - For a cover/OG image, add it to `public/blog/<slug>-cover.webp` and set the `image` frontmatter field to `/blog/<slug>-cover.webp`
+
+4. **Confirm** by listing the created file path and image directory path.

--- a/.claude/skills/update-uses/SKILL.md
+++ b/.claude/skills/update-uses/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: update-uses
+description: Add or update an item in src/data/uses.ts (coffee, software, hardware, or GitHub sections)
+disable-model-invocation: true
+---
+
+Add or update an entry in `src/data/uses.ts`. First read the file to show the user the current state of the relevant section, then collect missing fields.
+
+## Sections and their required fields
+
+| Section | Array | Fields | Needs image? |
+|---|---|---|---|
+| Coffee | `coffeeData` | title, description, imageSrc, link | Yes — `public/uses/<filename>.webp` |
+| Software | `softwareData` | title, description, imageSrc, link | Yes — `public/icons/<filename>.png` |
+| Hardware | `hardwareData` | title, description, link | No |
+| GitHub | `gitHubData` | title, description, link | No |
+
+## Steps
+
+1. Ask which section the user wants to update if not specified.
+
+2. Read `src/data/uses.ts` and show the current entries for that section.
+
+3. Collect all required fields for the section. For `imageSrc`:
+   - Coffee images live in `public/uses/` (use `.webp` format, e.g. `/uses/item-name.webp`)
+   - Software/app icons live in `public/icons/` (use `.png`, e.g. `/icons/app-name.png`)
+   - Remind the user to place the image file in the correct directory before the site is built.
+
+4. Append the new entry at the end of the correct array, matching the existing TypeScript object style (no trailing type annotation needed on the literal).
+
+5. Confirm with the added entry and a reminder about the image file if applicable.


### PR DESCRIPTION
## Summary

- Adds `/new-blog-post` skill to scaffold a new `.mdx` file with correct frontmatter, create the `src/assets/images/blog/<slug>/` directory, and remind about cover image placement in `public/blog/`
- Adds `/add-speaking` skill to insert a new entry into `speakingData` in `src/data/speaking.ts` in correct date-descending order
- Adds `/update-uses` skill to append to any section of `src/data/uses.ts` with typed field guidance and image path reminders
- Adds `blog-reviewer` subagent to check frontmatter completeness, verify image imports exist on disk, review prose voice/structure, and validate MDX before publishing

## Test plan

- [ ] Run `/new-blog-post` and verify it asks for missing fields, creates the `.mdx` with correct frontmatter, and creates the image directory
- [ ] Run `/add-speaking` and verify it inserts in correct date order
- [ ] Run `/update-uses` for each section type and verify correct fields are collected and image reminders appear where needed
- [ ] Ask Claude to "review my post" on an existing blog post and verify the agent produces a structured report

🤖 Generated with [Claude Code](https://claude.com/claude-code)