### PR TITLE
chore: convert to fully static output (Phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ pnpm typecheck        # TypeScript type checking
 
 ## Tech Stack
 
-- **Astro 7.x** on Cloudflare Workers
+- **Astro 7.x** — fully static build (`output: 'static'`, no adapter),
+  served as Cloudflare Workers static assets (see `wrangler.jsonc`)
 - **React 19.x** with `framer-motion` — currently used only by the mobile nav
 - **Tailwind CSS v4** with Vite plugin
 - **TypeScript** in strict mode
@@ -26,9 +27,11 @@ pnpm typecheck        # TypeScript type checking
 
 ### Rendering Strategy
 
-- Every page sets `prerender = true` — the site is effectively static.
-- The Cloudflare adapter runs in `output: 'server'` mode, but the only
-  dynamic route is `src/pages/robots.txt.ts`.
+- `output: 'static'` — every page and endpoint (including
+  `robots.txt.ts`) is prerendered to HTML/assets at build time. There is
+  no server runtime.
+- The build emits everything to `dist/`, which `wrangler` serves as
+  static assets. `pnpm deploy` runs `astro build && wrangler deploy`.
 - **Client-side interactivity**: React islands hydrate on the client
   (currently just the mobile nav).
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,4 @@
 // @ts-check
-import cloudflare from '@astrojs/cloudflare';
 import { rehypeHeadingIds } from '@astrojs/markdown-remark'
 import { unified } from '@astrojs/markdown-remark'
 import mdx from '@astrojs/mdx'
@@ -15,17 +14,6 @@ export default defineConfig({
   site: 'https://www.chrisnowicki.dev',
 
   vite: {
-    // Workaround for https://github.com/withastro/astro/issues/16387
-    // @astrojs/cloudflare fires buildStart on the client environment, causing a race
-    // condition that corrupts the dep optimizer metadata (react-dom never gets pre-bundled).
-    environments: {
-      client: {
-        optimizeDeps: {
-          noDiscovery: true,
-          include: ['react', 'react-dom', 'react-dom/client'],
-        },
-      },
-    },
     plugins: [
       tailwindcss(),
       {
@@ -81,11 +69,7 @@ export default defineConfig({
       ],
     }),
   },
-  adapter: cloudflare({
-    imageService: 'compile',
-    prerenderEnvironment: 'node',
-  }),
-  output: 'server',
+  output: 'static',
   prefetch: true,
 
   fonts: [

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "version": "1.0.0",
   "packageManager": "pnpm@11.5.2",
   "scripts": {
-    "dev": "wrangler types && astro dev",
-    "build": "wrangler types && astro build",
-    "preview": "wrangler types && astro preview",
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
     "astro": "astro",
+    "deploy": "astro build && wrangler deploy",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@astrojs/cloudflare": "^14.0.1",
     "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/mdx": "^7.0.0",
     "@astrojs/react": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@astrojs/cloudflare':
-        specifier: ^14.0.1
-        version: 14.0.1(@types/node@25.9.2)(astro@7.0.1(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.2)(jiti@2.6.1)(rollup@4.59.0))(esbuild@0.25.4)(jiti@2.6.1)(workerd@1.20260603.1)(wrangler@4.98.0)
       '@astrojs/markdown-remark':
         specifier: ^7.2.0
         version: 7.2.0
@@ -117,12 +114,6 @@ importers:
 
 packages:
 
-  '@astrojs/cloudflare@14.0.1':
-    resolution: {integrity: sha512-lbRA1khk7sN+NrzWrfFPIPgORtdyExvIPtlPVTSrjyf6oGmh419VwdGk1giRhtI6kO7AEFLvDNItmxt9vkEZRQ==}
-    peerDependencies:
-      astro: ^7.0.0-alpha.2
-      wrangler: ^4.83.0
-
   '@astrojs/compiler-binding-darwin-arm64@0.2.2':
     resolution: {integrity: sha512-1WxpECx3izz5X4Ha3l6ex79HZlUHpKBTElGJsfOosnhVvXhccfcXAsBlrYPNmUOKJWiG7mcrje0ELSr1KPE69Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -228,9 +219,6 @@ packages:
   '@astrojs/telemetry@3.3.2':
     resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
-
-  '@astrojs/underscore-redirects@1.0.3':
-    resolution: {integrity: sha512-cxnGSw+sJigBLdX4TMSZKkzV6C3gMLJMucDk2W+n281Xhie68T2/9f1+1NMNDCZsc5i0FED7Qt5I10g2O9wtZg==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -363,13 +351,6 @@ packages:
     peerDependenciesMeta:
       workerd:
         optional: true
-
-  '@cloudflare/vite-plugin@1.40.0':
-    resolution: {integrity: sha512-v77QQ2AdyBB+XW6uzKpWanbQy7ckYqSXFwJgQN871XITqLdJTdYOAWxt/jLPw9tNnHkKS6HTwV9+9bfQcLWz/w==}
-    hasBin: true
-    peerDependencies:
-      vite: ^6.1.0 || ^7.0.0 || ^8.0.0
-      wrangler: ^4.98.0
 
   '@cloudflare/workerd-darwin-64@1.20260603.1':
     resolution: {integrity: sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==}
@@ -4297,32 +4278,6 @@ packages:
 
 snapshots:
 
-  '@astrojs/cloudflare@14.0.1(@types/node@25.9.2)(astro@7.0.1(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.2)(jiti@2.6.1)(rollup@4.59.0))(esbuild@0.25.4)(jiti@2.6.1)(workerd@1.20260603.1)(wrangler@4.98.0)':
-    dependencies:
-      '@astrojs/internal-helpers': 0.10.0
-      '@astrojs/underscore-redirects': 1.0.3
-      '@cloudflare/vite-plugin': 1.40.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.4)(jiti@2.6.1))(workerd@1.20260603.1)(wrangler@4.98.0)
-      astro: 7.0.1(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.9.2)(jiti@2.6.1)(rollup@4.59.0)
-      piccolore: 0.1.3
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.25.4)(jiti@2.6.1)
-      wrangler: 4.98.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@vitejs/devtools'
-      - bufferutil
-      - esbuild
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - utf-8-validate
-      - workerd
-      - yaml
-
   '@astrojs/compiler-binding-darwin-arm64@0.2.2':
     optional: true
 
@@ -4485,8 +4440,6 @@ snapshots:
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
 
-  '@astrojs/underscore-redirects@1.0.3': {}
-
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -4638,19 +4591,6 @@ snapshots:
       unenv: 2.0.0-rc.24
     optionalDependencies:
       workerd: 1.20260603.1
-
-  '@cloudflare/vite-plugin@1.40.0(vite@8.0.16(@types/node@25.9.2)(esbuild@0.25.4)(jiti@2.6.1))(workerd@1.20260603.1)(wrangler@4.98.0)':
-    dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)
-      miniflare: 4.20260603.0
-      unenv: 2.0.0-rc.24
-      vite: 8.0.16(@types/node@25.9.2)(esbuild@0.25.4)(jiti@2.6.1)
-      wrangler: 4.98.0
-      ws: 8.20.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - workerd
 
   '@cloudflare/workerd-darwin-64@1.20260603.1':
     optional: true

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -8,8 +8,6 @@ import generateOgImageUrl from '@/utils/og-image'
 import { readingTime } from '@/utils/reading-time'
 import { formatDate } from '@/utils/utils'
 
-export const prerender = true
-
 export async function getStaticPaths() {
   const posts = await getCollection(
     'blog',

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -7,8 +7,6 @@ import generateOgImageUrl from '@/utils/og-image'
 import { readingTime } from '@/utils/reading-time'
 import { formatDate } from '@/utils/utils'
 
-export const prerender = true
-
 const posts = await getBlogPosts()
 
 const ogImageUrl = generateOgImageUrl({

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,8 +5,6 @@ import PageLayout from '@/layouts/PageLayout.astro'
 import { CONTACT } from '@/lib/site'
 import generateOgImageUrl from '@/utils/og-image'
 
-export const prerender = true
-
 const ogImageUrl = generateOgImageUrl({
   header: `/${CONTACT.TITLE.toUpperCase()}`,
   description: CONTACT.DESCRIPTION,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,6 @@ import Uses from '@/components/Uses.astro'
 import PageLayout from '@/layouts/PageLayout.astro'
 import { HOME } from '@/lib/site'
 
-export const prerender = true
 ---
 
 <PageLayout title={HOME.TITLE} description={HOME.DESCRIPTION}>

--- a/src/pages/speaking.astro
+++ b/src/pages/speaking.astro
@@ -6,8 +6,6 @@ import generateOgImageUrl from '@/utils/og-image'
 import { getSpeakingData } from '@/utils/speaking-helpers'
 import { formatDate } from '@/utils/utils'
 
-export const prerender = true
-
 const speaking = getSpeakingData()
 
 const ogImageUrl = generateOgImageUrl({

--- a/src/pages/uses.astro
+++ b/src/pages/uses.astro
@@ -11,8 +11,6 @@ import { USES } from '@/lib/site'
 import generateOgImageUrl from '@/utils/og-image'
 import { cn } from '@/utils/utils'
 
-export const prerender = true
-
 const ogImageUrl = generateOgImageUrl({
   header: `/${USES.TITLE.toUpperCase()}`,
   description: USES.DESCRIPTION,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,11 +1,8 @@
 {
-  "main": "@astrojs/cloudflare/entrypoints/server",
   "name": "portfolio",
   "compatibility_date": "2026-03-01",
-  "compatibility_flags": [
-    "nodejs_compat",
-    // Astro Font API uses module-level async state that persists across requests.
-    // Without this flag, the Workers runtime cancels cross-request promise continuations.
-    "no_handle_cross_request_promise_resolution"
-  ]
+  // Static site: no server code, just prerendered assets from `astro build`.
+  "assets": {
+    "directory": "./dist"
+  }
 }


### PR DESCRIPTION
Phase 2 of the simplification PRD (Phase 1 = #125, merged).

## What & why

Every page already sets `prerender = true`, so the Cloudflare SSR worker was doing nothing but adding a runtime, a build target, and a Vite workaround. This drops it.

- **`output: 'static'`, adapter removed** — the build now emits a flat `dist/` (was `dist/client` + `dist/server`).
- **Per-page `prerender` boilerplate removed** from all 6 pages — it's the default now. `robots.txt.ts` prerenders to a static file automatically.
- **`wrangler.jsonc` → Workers static assets** — serves `./dist`, no `main`, no runtime compat flags.
- **Vite `optimizeDeps` workaround removed** — it only existed to fix a react-dom pre-bundling race caused by the adapter, which is gone.
- **Scripts** — dropped the `wrangler types` prefix (no worker bindings to type); added `pnpm deploy` (`astro build && wrangler deploy`).
- **CLAUDE.md** rendering section updated.

## Verification (local)

- `pnpm build` ✓ — flat static `dist/`, 12 pages + `robots.txt` + sitemap
- `pnpm lint` ✓
- `pnpm typecheck` — only the 2 pre-existing `eslint.config.mjs` errors
- `wrangler deploy --dry-run` ✓ — reads all 117 assets, no bindings
- `pnpm dev` ✓ — boots, serves 200, mobile-nav island still hydrates

## ⚠️ Needs a real deploy check before merge

I can't see your Cloudflare dashboard. I assumed this is a **Workers** project (the old `wrangler.jsonc` had `main` pointing at the adapter's SSR entrypoint) and moved it to the Workers **static-assets** pattern. Before merging, confirm one deploy succeeds and the live site serves — especially if your dashboard has an explicit build-output-directory override (it would need to point at `dist`, not `dist/client`), or if you're actually on Cloudflare Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)